### PR TITLE
Use correct device_id for Jupyter notebook example

### DIFF
--- a/data-platform/jupyter-notebook/FoxgloveDataPlatform.ipynb
+++ b/data-platform/jupyter-notebook/FoxgloveDataPlatform.ipynb
@@ -86,8 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "device_id = \"dev_fj7b6mZSD54rJO7v\"      # use this device ID to get ROS1-encoded messages.\n",
-    "# device_id = \"dev_KphdijgpmmnnmYaH\"    # use this device ID to get ROS2 CDR-encoded messages.\n",
+    "device_id = \"dev_cJEWbnootvtj8e4p\",
     "coverage = [r for r in all_devices_coverage if r[\"device_id\"] == device_id]"
    ]
   },

--- a/data-platform/jupyter-notebook/FoxgloveDataPlatform.ipynb
+++ b/data-platform/jupyter-notebook/FoxgloveDataPlatform.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "device_id = \"dev_cJEWbnootvtj8e4p\",
+    "device_id = \"dev_cJEWbnootvtj8e4p\"",
     "coverage = [r for r in all_devices_coverage if r[\"device_id\"] == device_id]"
    ]
   },


### PR DESCRIPTION
### Public-Facing Changes

- Use correct device_id for Jupyter notebook example 